### PR TITLE
externalize html tag names

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
       "commit-msg": "node ./node_modules/validate-commit-msg/index.js"
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "html-tag-names": "^1.0.0"
+  },
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-eslint": "^4.1.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import tagNames from 'html-tag-names'
+import tagNames from 'html-tag-names';
 
 const isValidString =
   param =>

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import tagNames from 'html-tag-names'
+
 const isValidString =
   param =>
     typeof param === 'string' && param.length > 0;
@@ -23,25 +25,11 @@ const node =
         }
       };
 
-const TAG_NAMES = [
-  'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base',
-  'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption',
-  'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'dfn', 'dir', 'div', 'dl',
-  'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form',
-  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html',
-  'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'keygen', 'label', 'legend',
-  'li', 'link', 'main', 'map', 'mark', 'menu', 'meta', 'nav', 'noscript',
-  'object', 'ol', 'optgroup', 'option', 'p', 'param', 'pre', 'q', 'rp', 'rt',
-  'ruby', 's', 'samp', 'script', 'section', 'select', 'small', 'source', 'span',
-  'strong', 'style', 'sub', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot',
-  'th', 'thead', 'title', 'tr', 'u', 'ul', 'video', 'progress'
-];
-
 export default
   h => {
     const createTag = node(h);
-    const exported = { TAG_NAMES, isSelector, createTag };
-    TAG_NAMES.forEach(n => {
+    const exported = { tagNames, isSelector, createTag };
+    tagNames.forEach(n => {
       exported[n] = createTag(n);
     });
     return exported;


### PR DESCRIPTION
A lot of libraries are not reeusing that html tag list and are creating them for every module. This creates quite a lot of duplication. Feel free to close if you are not interesting in any external deps
