### PR TITLE
Remove html-tag-names dependency from source

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,13 +3,6 @@
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _htmlTagNames = require('html-tag-names');
-
-var _htmlTagNames2 = _interopRequireDefault(_htmlTagNames);
-
 var isValidString = function isValidString(param) {
   return typeof param === 'string' && param.length > 0;
 };
@@ -40,10 +33,12 @@ var node = function node(h) {
   };
 };
 
+var TAG_NAMES = ['a', 'abbr', 'acronym', 'address', 'applet', 'area', 'article', 'aside', 'audio', 'b', 'base', 'basefont', 'bdi', 'bdo', 'bgsound', 'big', 'blink', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'center', 'cite', 'code', 'col', 'colgroup', 'command', 'content', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'dir', 'div', 'dl', 'dt', 'element', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'font', 'footer', 'form', 'frame', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'image', 'img', 'input', 'ins', 'isindex', 'kbd', 'keygen', 'label', 'legend', 'li', 'link', 'listing', 'main', 'map', 'mark', 'marquee', 'math', 'menu', 'menuitem', 'meta', 'meter', 'multicol', 'nav', 'nextid', 'nobr', 'noembed', 'noframes', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'plaintext', 'pre', 'progress', 'q', 'rb', 'rbc', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select', 'shadow', 'small', 'source', 'spacer', 'span', 'strike', 'strong', 'style', 'sub', 'summary', 'sup', 'svg', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'tt', 'u', 'ul', 'var', 'video', 'wbr', 'xmp'];
+
 exports['default'] = function (h) {
   var createTag = node(h);
-  var exported = { tagNames: _htmlTagNames2['default'], isSelector: isSelector, createTag: createTag };
-  _htmlTagNames2['default'].forEach(function (n) {
+  var exported = { TAG_NAMES: TAG_NAMES, isSelector: isSelector, createTag: createTag };
+  TAG_NAMES.forEach(function (n) {
     exported[n] = createTag(n);
   });
   return exported;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperscript-helpers",
-  "version": "2.1.1",
+  "version": "3.0.1",
   "description": "Terse syntax for hyperscript",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,13 @@
       "commit-msg": "node ./node_modules/validate-commit-msg/index.js"
     }
   },
-  "dependencies": {
-    "html-tag-names": "^1.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-eslint": "^4.1.4",
     "commitizen": "^2.5.0",
     "eslint": "^1.9.0",
+    "html-tag-names": "^1.0.0",
     "hyperscript": "^1.4.6",
     "jsverify": "^0.6.0",
     "lodash": "^3.10.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import tagNames from 'html-tag-names';
-
 const isValidString =
   param =>
     typeof param === 'string' && param.length > 0;
@@ -25,11 +23,29 @@ const node =
         }
       };
 
+const TAG_NAMES = [
+  'a', 'abbr', 'acronym', 'address', 'applet', 'area', 'article', 'aside', 'audio', 'b',
+  'base', 'basefont', 'bdi', 'bdo', 'bgsound', 'big', 'blink', 'blockquote', 'body',
+  'br', 'button', 'canvas', 'caption', 'center', 'cite', 'code', 'col', 'colgroup',
+  'command', 'content', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog',
+  'dir', 'div', 'dl', 'dt', 'element', 'em', 'embed', 'fieldset', 'figcaption', 'figure',
+  'font', 'footer', 'form', 'frame', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'image', 'img', 'input',
+  'ins', 'isindex', 'kbd', 'keygen', 'label', 'legend', 'li', 'link', 'listing', 'main',
+  'map', 'mark', 'marquee', 'math', 'menu', 'menuitem', 'meta', 'meter', 'multicol',
+  'nav', 'nextid', 'nobr', 'noembed', 'noframes', 'noscript', 'object', 'ol', 'optgroup',
+  'option', 'output', 'p', 'param', 'picture', 'plaintext', 'pre', 'progress', 'q', 'rb',
+  'rbc', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select', 'shadow',
+  'small', 'source', 'spacer', 'span', 'strike', 'strong', 'style', 'sub', 'summary',
+  'sup', 'svg', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead',
+  'time', 'title', 'tr', 'track', 'tt', 'u', 'ul', 'var', 'video', 'wbr', 'xmp'
+];
+
 export default
   h => {
     const createTag = node(h);
-    const exported = { tagNames, isSelector, createTag };
-    tagNames.forEach(n => {
+    const exported = { TAG_NAMES, isSelector, createTag };
+    TAG_NAMES.forEach(n => {
       exported[n] = createTag(n);
     });
     return exported;


### PR DESCRIPTION
Because of issues mentioned in #34, I decided to use `html-tag-names` only to verify the tag names in the tests. This circumvents the non-standardized import/export of the npm world and still should keep the source up to date.
