### PR TITLE
Simplify using Proxy to allow any tag name by default

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15,33 +15,34 @@ var isSelector = function isSelector(param) {
   return isValidString(param) && (startsWith(param, '.') || startsWith(param, '#'));
 };
 
-var node = function node(h) {
-  return function (tagName) {
-    return function (first) {
-      for (var _len = arguments.length, rest = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-        rest[_key - 1] = arguments[_key];
-      }
-
-      if (isSelector(first)) {
-        return h.apply(undefined, [tagName + first].concat(rest));
-      } else if (typeof first === 'undefined') {
-        return h(tagName);
-      } else {
-        return h.apply(undefined, [tagName, first].concat(rest));
-      }
-    };
-  };
-};
-
-var TAG_NAMES = ['a', 'abbr', 'acronym', 'address', 'applet', 'area', 'article', 'aside', 'audio', 'b', 'base', 'basefont', 'bdi', 'bdo', 'bgsound', 'big', 'blink', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'center', 'cite', 'code', 'col', 'colgroup', 'command', 'content', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'dir', 'div', 'dl', 'dt', 'element', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'font', 'footer', 'form', 'frame', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'image', 'img', 'input', 'ins', 'isindex', 'kbd', 'keygen', 'label', 'legend', 'li', 'link', 'listing', 'main', 'map', 'mark', 'marquee', 'math', 'menu', 'menuitem', 'meta', 'meter', 'multicol', 'nav', 'nextid', 'nobr', 'noembed', 'noframes', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'plaintext', 'pre', 'progress', 'q', 'rb', 'rbc', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select', 'shadow', 'slot', 'small', 'source', 'spacer', 'span', 'strike', 'strong', 'style', 'sub', 'summary', 'sup', 'svg', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'tt', 'u', 'ul', 'var', 'video', 'wbr', 'xmp'];
-
 exports['default'] = function (h) {
-  var createTag = node(h);
-  var exported = { TAG_NAMES: TAG_NAMES, isSelector: isSelector, createTag: createTag };
-  TAG_NAMES.forEach(function (n) {
-    exported[n] = createTag(n);
+  // Inspired by https://stackoverflow.com/a/40075864/645498
+  return new Proxy({}, {
+    get: function get(target, property) {
+      switch (property) {
+        case 'TAG_NAMES':
+          return []; // TODO: Still useful? How to preserve backward compatibility?
+        case 'createTag':
+          return function () {}; // TODO: Preserve for backward compatibility?
+        case 'isSelector':
+          return isSelector; // TODO: Still useful to expose this?
+        default:
+          return function (first) {
+            for (var _len = arguments.length, rest = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+              rest[_key - 1] = arguments[_key];
+            }
+
+            if (isSelector(first)) {
+              return h.apply(undefined, [property + first].concat(rest));
+            } else if (typeof first === 'undefined') {
+              return h(property);
+            } else {
+              return h.apply(undefined, [property, first].concat(rest));
+            }
+          };
+      }
+    }
   });
-  return exported;
 };
 
 module.exports = exports['default'];

--- a/dist/svg.js
+++ b/dist/svg.js
@@ -1,3 +1,4 @@
+// TODO: Keep this file for backward compatibility?
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -10,16 +11,8 @@ var _index = require('./index');
 
 var _index2 = _interopRequireDefault(_index);
 
-// https://www.w3.org/TR/SVG/eltindex.html
-var TAG_NAMES = ['a', 'altGlyph', 'altGlyphDef', 'altGlyphItem', 'animate', 'animateColor', 'animateMotion', 'animateTransform', 'circle', 'clipPath', 'colorProfile', 'cursor', 'defs', 'desc', 'ellipse', 'feBlend', 'feColorMatrix', 'feComponentTransfer', 'feComposite', 'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap', 'feDistantLight', 'feFlood', 'feFuncA', 'feFuncB', 'feFuncG', 'feFuncR', 'feGaussianBlur', 'feImage', 'feMerge', 'feMergeNode', 'feMorphology', 'feOffset', 'fePointLight', 'feSpecularLighting', 'feSpotlight', 'feTile', 'feTurbulence', 'filter', 'font', 'fontFace', 'fontFaceFormat', 'fontFaceName', 'fontFaceSrc', 'fontFaceUri', 'foreignObject', 'g', 'glyph', 'glyphRef', 'hkern', 'image', 'line', 'linearGradient', 'marker', 'mask', 'metadata', 'missingGlyph', 'mpath', 'path', 'pattern', 'polygon', 'polyline', 'radialGradient', 'rect', 'script', 'set', 'stop', 'style', 'switch', 'symbol', 'text', 'textPath', 'title', 'tref', 'tspan', 'use', 'view', 'vkern'];
-
 exports['default'] = function (h) {
-  var createTag = (0, _index2['default'])(h).createTag;
-  var exported = { TAG_NAMES: TAG_NAMES };
-  TAG_NAMES.forEach(function (n) {
-    exported[n] = createTag(n);
-  });
-  return exported;
+  return (0, _index2['default'])(h);
 };
 
 module.exports = exports['default'];

--- a/src/index.js
+++ b/src/index.js
@@ -5,172 +5,28 @@ const startsWith = (string, start) => string[0] === start;
 const isSelector = param =>
   isValidString(param) && (startsWith(param, '.') || startsWith(param, '#'));
 
-const node = h => tagName => (first, ...rest) => {
-  if (isSelector(first)) {
-    return h(tagName + first, ...rest);
-  } else if (typeof first === 'undefined') {
-    return h(tagName);
-  } else {
-    return h(tagName, first, ...rest);
-  }
-};
-
-const TAG_NAMES = [
-  'a',
-  'abbr',
-  'acronym',
-  'address',
-  'applet',
-  'area',
-  'article',
-  'aside',
-  'audio',
-  'b',
-  'base',
-  'basefont',
-  'bdi',
-  'bdo',
-  'bgsound',
-  'big',
-  'blink',
-  'blockquote',
-  'body',
-  'br',
-  'button',
-  'canvas',
-  'caption',
-  'center',
-  'cite',
-  'code',
-  'col',
-  'colgroup',
-  'command',
-  'content',
-  'data',
-  'datalist',
-  'dd',
-  'del',
-  'details',
-  'dfn',
-  'dialog',
-  'dir',
-  'div',
-  'dl',
-  'dt',
-  'element',
-  'em',
-  'embed',
-  'fieldset',
-  'figcaption',
-  'figure',
-  'font',
-  'footer',
-  'form',
-  'frame',
-  'frameset',
-  'h1',
-  'h2',
-  'h3',
-  'h4',
-  'h5',
-  'h6',
-  'head',
-  'header',
-  'hgroup',
-  'hr',
-  'html',
-  'i',
-  'iframe',
-  'image',
-  'img',
-  'input',
-  'ins',
-  'isindex',
-  'kbd',
-  'keygen',
-  'label',
-  'legend',
-  'li',
-  'link',
-  'listing',
-  'main',
-  'map',
-  'mark',
-  'marquee',
-  'math',
-  'menu',
-  'menuitem',
-  'meta',
-  'meter',
-  'multicol',
-  'nav',
-  'nextid',
-  'nobr',
-  'noembed',
-  'noframes',
-  'noscript',
-  'object',
-  'ol',
-  'optgroup',
-  'option',
-  'output',
-  'p',
-  'param',
-  'picture',
-  'plaintext',
-  'pre',
-  'progress',
-  'q',
-  'rb',
-  'rbc',
-  'rp',
-  'rt',
-  'rtc',
-  'ruby',
-  's',
-  'samp',
-  'script',
-  'section',
-  'select',
-  'shadow',
-  'slot',
-  'small',
-  'source',
-  'spacer',
-  'span',
-  'strike',
-  'strong',
-  'style',
-  'sub',
-  'summary',
-  'sup',
-  'svg',
-  'table',
-  'tbody',
-  'td',
-  'template',
-  'textarea',
-  'tfoot',
-  'th',
-  'thead',
-  'time',
-  'title',
-  'tr',
-  'track',
-  'tt',
-  'u',
-  'ul',
-  'var',
-  'video',
-  'wbr',
-  'xmp'
-];
-
 export default h => {
-  const createTag = node(h);
-  const exported = { TAG_NAMES, isSelector, createTag };
-  TAG_NAMES.forEach(n => {
-    exported[n] = createTag(n);
+  // Inspired by https://stackoverflow.com/a/40075864/645498
+  return new Proxy({}, {
+    get(target, property) {
+      switch (property) {
+      case 'TAG_NAMES':
+        return [];  // TODO: Still useful? How to preserve backward compatibility?
+      case 'createTag':
+        return () => {};  // TODO: Preserve for backward compatibility?
+      case 'isSelector':
+        return isSelector;  // TODO: Still useful to expose this?
+      default:
+        return (first, ...rest) => {
+          if (isSelector(first)) {
+            return h(property + first, ...rest);
+          } else if (typeof first === 'undefined') {
+            return h(property);
+          } else {
+            return h(property, first, ...rest);
+          }
+        };
+      }
+    }
   });
-  return exported;
 };

--- a/src/svg.js
+++ b/src/svg.js
@@ -1,30 +1,6 @@
-
+// TODO: Keep this file for backward compatibility?
 import hh from './index';
 
-// https://www.w3.org/TR/SVG/eltindex.html
-const TAG_NAMES = [
-  'a', 'altGlyph', 'altGlyphDef', 'altGlyphItem', 'animate', 'animateColor',
-  'animateMotion', 'animateTransform', 'circle', 'clipPath', 'colorProfile',
-  'cursor', 'defs', 'desc', 'ellipse', 'feBlend', 'feColorMatrix',
-  'feComponentTransfer', 'feComposite', 'feConvolveMatrix', 'feDiffuseLighting',
-  'feDisplacementMap', 'feDistantLight', 'feFlood', 'feFuncA', 'feFuncB',
-  'feFuncG', 'feFuncR', 'feGaussianBlur', 'feImage', 'feMerge', 'feMergeNode',
-  'feMorphology', 'feOffset', 'fePointLight', 'feSpecularLighting',
-  'feSpotlight', 'feTile', 'feTurbulence', 'filter', 'font', 'fontFace',
-  'fontFaceFormat', 'fontFaceName', 'fontFaceSrc', 'fontFaceUri',
-  'foreignObject', 'g', 'glyph', 'glyphRef', 'hkern', 'image', 'line',
-  'linearGradient', 'marker', 'mask', 'metadata', 'missingGlyph', 'mpath',
-  'path', 'pattern', 'polygon', 'polyline', 'radialGradient', 'rect', 'script',
-  'set', 'stop', 'style', 'switch', 'symbol', 'text', 'textPath', 'title',
-  'tref', 'tspan', 'use', 'view', 'vkern'
-];
-
-export default
-  h => {
-    const createTag = hh(h).createTag;
-    const exported = { TAG_NAMES };
-    TAG_NAMES.forEach(n => {
-      exported[n] = createTag(n);
-    });
-    return exported;
-  };
+export default h => {
+  return hh(h);
+};


### PR DESCRIPTION
Hi, I really like using hyperscript with this syntax, but I was wondering why there must be a fixed list of html tags and the need to create custom ones with the special `createTag` function.

Assuming that there's no particular reason, this patch simplifies everything a lot by just using a Proxy object to practically create tags "on demand", without a fixed list. It was originally inspired by https://stackoverflow.com/a/40075864/645498

Technically there are more seemingly redundant parts that could be removed, but I've left them with TODO comments, since I fear that removing them could break backward compatibility.

One reason why I wanted to use custom tags is that I prefer using them with the first letter uppercase, e.g. `Div('#main', mainContents)` instead of `div('#main', mainContents)`. This is also to better prevent conflicts with other variables in the code, which are usually spelled lowercase, or even with JS keywords, e.g. the `var` tag.

All the tests are passing, but let me know what you think, since I may have totally missed the point why a fixed list of tags is used.